### PR TITLE
Minor updates needed to get cl-ml running

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Martin Kersner, <m.kersner@gmail.com>
 * [Artificial Neural Networks](https://github.com/martinkersner/cl-ml#artificial-neural-networks)
 
 ### Requirements
-`cl-ml` requires [asdf](https://gitlab.common-lisp.net/asdf/asdf.git) to be installed. [`cl-math`](https://github.com/martinkersner/cl-math.git) and [`cl-plot`](https://github.com/martinkersner/cl-plot.git) are included as submodules to `cl-ml` project.
+`cl-ml` requires [CLISP](https://www.gnu.org/software/clisp/) and [ASDF](https://gitlab.common-lisp.net/asdf/asdf.git) >= 3.1. [`cl-math`](https://github.com/martinkersner/cl-math.git) and [`cl-plot`](https://github.com/martinkersner/cl-plot.git) are included as submodules to `cl-ml` project.
 
 ### Get the latest version
 ```bash

--- a/cl-ml.asd
+++ b/cl-ml.asd
@@ -11,7 +11,6 @@
   :version "0.1"
   :author  "Martin Kersner, <m.kersner@gmail.com>"
   :long-description "Machine Learning library for Common Lisp"
-  :defsystem-depends-on (:asdf-package-system)
   :depends-on ("cl-math" "cl-plot")
   ;:serial t
   :components ((:file "feature-extraction-and-preprocessing")


### PR DESCRIPTION
I came upon some minor bumps while trying to get `cl-ml` running, and here's what I've found:
- `cl-ml` uses `EXT` package from CLISP, so it won't work with e.g. SBCL;
- `asdf-package-system` is unsupported now, but ASDF >= 3.1 comes with this feature built-in (see [here](http://quickdocs.org/asdf-package-system/)).

This PR addresses these two issues.